### PR TITLE
Store error classes.

### DIFF
--- a/lib/YepError.js
+++ b/lib/YepError.js
@@ -1,7 +1,7 @@
 import Enum from "enumit";
 
 var Errors = new Enum("UNKNOWN");
-var allErrors = { 100: { name: "YepError", Errors }};
+var allErrors = {};
 
 export default class YepError extends Error {
     constructor(key = "UNKNOWN", { message, details } = {}) {
@@ -85,7 +85,7 @@ export default class YepError extends Error {
             Object.defineProperty(target, "Errors", { get: () => options.Errors });
             Object.defineProperty(target.prototype, "title", { get: () => options.title });
 
-            allErrors[groupCode] = { name: options.title, Errors: options.Errors};
+            allErrors[groupCode] = target;
         };
     }
 


### PR DESCRIPTION
Previously manually stored the title and error options, now we store the class itself, which will allow us to new them up for our errors page and just looks a lot cleaner.
